### PR TITLE
Add option to build with different database types (#13)

### DIFF
--- a/Dockerfile.patch
+++ b/Dockerfile.patch
@@ -22,7 +22,7 @@
  
  # Make sure that we actually build the project
  RUN touch src/main.rs
-@@ -62,34 +62,25 @@
+@@ -62,10 +62,6 @@
  # because we already have a binary built
  FROM debian:buster-slim
  
@@ -30,15 +30,13 @@
 -ENV ROCKET_PORT=80
 -ENV ROCKET_WORKERS=10
 -
--# Install needed libraries
--RUN apt-get update && apt-get install -y \
--    --no-install-recommends \
--    openssl \
--    ca-certificates \
--    curl \
--    sqlite3 \
--    && rm -rf /var/lib/apt/lists/*
--
+ # Install needed libraries
+ RUN apt-get update && apt-get install -y \
+     --no-install-recommends \
+@@ -75,21 +71,25 @@
+     sqlite3 \
+     && rm -rf /var/lib/apt/lists/*
+ 
 -RUN mkdir /data
 -VOLUME /data
 -EXPOSE 80

--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SRC="$DIR/git"
 DST="$DIR/dist"
 
-while getopts ":r:o:" opt; do
+while getopts ":r:o:d:" opt; do
   case $opt in
     r) REF="$OPTARG"
     ;;
     o) OS_VERSION_NAME="$OPTARG"
+    ;;
+    d) DB_TYPE="$OPTARG"
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     ;;
@@ -18,6 +20,7 @@ while getopts ":r:o:" opt; do
 done
 if [ -z "$REF" ]; then REF="1.14.2"; fi
 if [ -z "$OS_VERSION_NAME" ]; then OS_VERSION_NAME='buster'; fi
+if [ -z "$DB_TYPE" ]; then DB_TYPE="sqlite"; fi
 
 # Clone bitwarden_rs
 if [ ! -d "$SRC" ]; then
@@ -43,12 +46,20 @@ sed -i "s#\# WEB_VAULT_FOLDER=web-vault/#WEB_VAULT_FOLDER=/usr/share/bitwarden_r
 mkdir -p "$DST"
 
 # Prepare Dockerfile
-patch -i "$DIR/Dockerfile.patch" "$SRC/docker/amd64/sqlite/Dockerfile" -o "$DIR/Dockerfile" || exit
+patch -i "$DIR/Dockerfile.patch" "$SRC/docker/amd64/$DB_TYPE/Dockerfile" -o "$DIR/Dockerfile" || exit
 sed -E "s/(FROM[[:space:]]*rust:)[^[:space:]]+(.+)/\1${OS_VERSION_NAME}\2/g" -i "$DIR/Dockerfile"
 sed -E "s/(FROM[[:space:]]*debian:)[^-]+(-.+)/\1${OS_VERSION_NAME}\2/g" -i "$DIR/Dockerfile"
+
+# Prepare Systemd-unit
+SYSTEMD_UNIT="$DIR/debian/bitwarden_rs.service"
+if [ "$DB_TYPE" = "mysql" ]; then
+  sed -i "s/After=network.target/After=network.target mysqld.service\nRequires=mysqld.service/g" "$SYSTEMD_UNIT"
+elif [ "$DB_TYPE" = "postgresql" ]; then
+  sed -i "s/After=network.target/After=network.target postgresql.service\nRequires=postgresql.service/g" "$SYSTEMD_UNIT"
+fi
 
 docker build -t bitwarden-deb "$DIR"
 
 CID=$(docker run -d bitwarden-deb)
-docker cp "$CID":/bitwarden_package/bitwarden-rs.deb "$DST/bitwarden_rs-${OS_VERSION_NAME}-${REF}.deb"
+docker cp "$CID":/bitwarden_package/bitwarden-rs.deb "$DST/bitwarden_rs-${OS_VERSION_NAME}-${REF}-${DB_TYPE}.deb"
 docker rm "$CID"


### PR DESCRIPTION
* Add argument for database type

The optional argument "-d" allows to customize the database type.

* Modify patch to work with all db types

* Add database type to filename

* Add dynamic modification of systemd-unit

Dynamically changes the systemd-unit to require the appropriate database service.